### PR TITLE
Fix typo in Recipes comment explanation

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ app.post('/shopping-list', jsonParser, (req, res) => {
 // log error and return 400 status code with hepful message.
 // if okay, add new item, and return it with a status 201.
 app.post('/recipes', jsonParser, (req, res) => {
-  // ensure `name` and `budget` are in request body
+  // ensure `name` and `ingredients` are in request body
   const requiredFields = ['name', 'ingredients'];
   for (let i=0; i<requiredFields.length; i++) {
     const field = requiredFields[i];


### PR DESCRIPTION
The comment wrongly states "ensure `name` and `budget` are in request body" for the Recipes POST request instead of "ensure `name` and `ingredients` are in request body".